### PR TITLE
chore: bump version to v1.20.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,7 @@ Patch release.
 
 * **mvgen**: Fixed code generation for `option` types in storage and parameters
   - Parser now preserves option as `ast.Struct{ MichelineType: "option", Type: inner }` instead of unwrapping to inner type
-  - Generated storage structs get `bind.Option[T]` for optional fields (e.g. `NewSuperAdmin bind.Option[mavryk.Address]`)
+  - Generated storage structs get `bind.Option[T]` for optional fields (e.g. `SomeProp bind.Option[mavryk.Address]`)
   - Enables correct origination with optional fields set to `None` (e.g. `bind.None[mavryk.Address]()`)
 
 ## v1.20.0

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,16 @@
 # Changelog
 
+## v1.20.1
+
+Patch release.
+
+### Bug Fixes
+
+* **mvgen**: Fixed code generation for `option` types in storage and parameters
+  - Parser now preserves option as `ast.Struct{ MichelineType: "option", Type: inner }` instead of unwrapping to inner type
+  - Generated storage structs get `bind.Option[T]` for optional fields (e.g. `NewSuperAdmin bind.Option[mavryk.Address]`)
+  - Enables correct origination with optional fields set to `None` (e.g. `bind.None[mavryk.Address]()`)
+
 ## v1.20.0
 
 Mavryk rebranding and tooling updates

--- a/internal/parse/type.go
+++ b/internal/parse/type.go
@@ -6,13 +6,17 @@ import (
 )
 
 func (p *parser) buildTypeStructs(t *m.Typedef) (*ast.Struct, error) {
-	// Unwrap optional
+	// Preserve option so generated code uses bind.Option[T] (e.g. for storage newSuperAdmin)
 	if t.Optional {
-		typ, err := p.buildTypeStructs(&m.Typedef{Name: t.Name, Type: t.Type, Args: t.Args})
+		inner, err := p.buildTypeStructs(&m.Typedef{Name: "", Type: t.Type, Args: t.Args})
 		if err != nil {
 			return nil, err
 		}
-		return typ, nil
+		return &ast.Struct{
+			Name:          t.Name,
+			MichelineType: "option",
+			Type:          inner,
+		}, nil
 	}
 	// Builtin types
 	if op, err := m.ParseOpCode(t.Type); err == nil {

--- a/internal/parse/type.go
+++ b/internal/parse/type.go
@@ -6,7 +6,7 @@ import (
 )
 
 func (p *parser) buildTypeStructs(t *m.Typedef) (*ast.Struct, error) {
-	// Preserve option so generated code uses bind.Option[T] (e.g. for storage newSuperAdmin)
+	// Preserve option so generated code uses bind.Option[T]
 	if t.Optional {
 		inner, err := p.buildTypeStructs(&m.Typedef{Name: "", Type: t.Type, Args: t.Args})
 		if err != nil {

--- a/rpc/client.go
+++ b/rpc/client.go
@@ -22,7 +22,7 @@ import (
 )
 
 const (
-	libraryVersion = "1.20.0"
+	libraryVersion = "1.20.1"
 	userAgent      = "mvgo/v" + libraryVersion
 	mediaType      = "application/json"
 	ipfsUrl        = "https://ipfs.io"


### PR DESCRIPTION
# Release v1.20.1

Patch release.

## Bug Fixes

* **mvgen**: Fixed code generation for `option` types in storage and parameters
  - Parser now preserves option as `ast.Struct{ MichelineType: "option", Type: inner }` instead of unwrapping to inner type
  - Generated storage structs get `bind.Option[T]` for optional fields (e.g. `SomeProp bind.Option[mavryk.Address]`)
  - Enables correct origination with optional fields set to `None` (e.g. `bind.None[mavryk.Address]()`)

## Upgrade

```bash
go get github.com/mavryk-network/mvgo@v1.20.1
```

See [CHANGELOG.md](CHANGELOG.md) for full details.
